### PR TITLE
fixed issue with shapely import

### DIFF
--- a/gj2ascii/core.py
+++ b/gj2ascii/core.py
@@ -13,12 +13,12 @@ from types import GeneratorType
 
 from .pycompat import text_type
 
+from shapely.geometry import asShape
+from shapely.geometry import mapping
 import affine
 import numpy as np
 import rasterio as rio
 from rasterio.features import rasterize
-from shapely.geometry import asShape
-from shapely.geometry import mapping
 try:  # pragma no cover
     import emoji
 except ImportError:  # pragma no cover


### PR DESCRIPTION
I constantly had this error on OSX :

```
Failed `CDLL(/usr/local/lib/libgeos_c.dylib)`
Failed `CDLL(/Library/Frameworks/GEOS.framework/Versions/Current/GEOS)`
Failed `CDLL(/opt/local/lib/libgeos_c.dylib)`
Traceback (most recent call last):
  File "/Users/erik/Library/Python/2.7/bin/gj2ascii", line 7, in <module>
    from gj2ascii.cli import main
  File "/Users/erik/Library/Python/2.7/lib/python/site-packages/gj2ascii/__init__.py", line 39, in <module>
    from .core import (
  File "/Users/erik/Library/Python/2.7/lib/python/site-packages/gj2ascii/core.py", line 20, in <module>
    from shapely.geometry import asShape
  File "/Library/Frameworks/GEOS.framework/Versions/3/Python/2.7/site-packages/shapely/geometry/__init__.py", line 4, in <module>
    from .base import CAP_STYLE, JOIN_STYLE
  File "/Library/Frameworks/GEOS.framework/Versions/3/Python/2.7/site-packages/shapely/geometry/base.py", line 9, in <module>
    from shapely.coords import CoordinateSequence
  File "/Library/Frameworks/GEOS.framework/Versions/3/Python/2.7/site-packages/shapely/coords.py", line 8, in <module>
    from shapely.geos import lgeos
  File "/Library/Frameworks/GEOS.framework/Versions/3/Python/2.7/site-packages/shapely/geos.py", line 92, in <module>
    mode=(DEFAULT_MODE | 16))
  File "/Library/Frameworks/GEOS.framework/Versions/3/Python/2.7/site-packages/shapely/geos.py", line 61, in load_dll
    libname, fallbacks or []))
OSError: Could not find lib geos_c or load any of its variants ['/Library/Frameworks/GEOS.framework/Versions/Current/GEOS', '/opt/local/lib/libgeos_c.dylib'].
```

This fixes it for me, as per this [issue](https://github.com/aleaf/GIS_utils/issues/5).

Note : I don't know much python, and I have no idea what the underlying problem is, plz ignore if irrelevant.
